### PR TITLE
CLDCONNECT-2280 - Fix for Twitter connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.mule.modules</groupId>
 	<artifactId>mule-module-twitter</artifactId>
-	<version>3.2.1-SNAPSHOT</version>
+	<version>4.0.0-SNAPSHOT</version>
 	<packaging>mule-module</packaging>
 	<name>Mule Twitter Connector</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
 	</parent>
 
 	<properties>
+		<mule.version>3.6.0</mule.version>
 		<category>Community</category>
 		<licensePath>LICENSE.md</licensePath>
 		<devkit.studio.package.skip>false</devkit.studio.package.skip>

--- a/src/main/java/org/mule/twitter/TwitterConnector.java
+++ b/src/main/java/org/mule/twitter/TwitterConnector.java
@@ -41,7 +41,7 @@ import java.util.Map;
  * @author MuleSoft, Inc.
  */
 @Connector(name = "twitter", schemaVersion = "2.4", description = "Twitter Integration", friendlyName = "Twitter",
-        minMuleVersion = "3.5")
+        minMuleVersion = "3.6")
 public class TwitterConnector implements MuleContextAware {
 
     protected transient Log logger = LogFactory.getLog(getClass());

--- a/src/main/java/twitter4j/internal/http/alternative/MuleHttpClient.java
+++ b/src/main/java/twitter4j/internal/http/alternative/MuleHttpClient.java
@@ -16,8 +16,7 @@ import org.mule.api.client.MuleClient;
 import org.mule.api.transport.OutputHandler;
 import org.mule.client.DefaultLocalMuleClient;
 import org.mule.module.http.api.client.HttpRequestOptions;
-import org.mule.module.http.api.requester.HttpStreamingType;
-import org.mule.module.http.internal.request.client.DefaultHttpRequestOptions;
+import org.mule.module.http.api.client.HttpRequestOptionsBuilder;
 import org.mule.transport.http.HttpConnector;
 import org.mule.twitter.MuleHttpResponse;
 import twitter4j.TwitterException;
@@ -106,8 +105,9 @@ public class MuleHttpClient implements HttpClient {
             msg.setOutboundProperty("Authorization", authorizationHeader);
         }
         try {
-            HttpRequestOptions operationOptions = new DefaultHttpRequestOptions(req.getMethod().name(), true, HttpStreamingType.AUTO,
-                    null, true, true, null, new Long(httpConf.getHttpReadTimeout()));
+
+            HttpRequestOptions operationOptions = HttpRequestOptionsBuilder.newOptions().
+                    method(req.getMethod().name()).build();
             return new MuleHttpResponse(httpConf, client.send(req.getURL(), msg, operationOptions));
         } catch (MuleException e) {
             throw new TwitterException(e);

--- a/src/main/java/twitter4j/internal/http/alternative/MuleHttpClient.java
+++ b/src/main/java/twitter4j/internal/http/alternative/MuleHttpClient.java
@@ -8,8 +8,6 @@
 
 package twitter4j.internal.http.alternative;
 
-import static twitter4j.internal.http.RequestMethod.POST;
-
 import org.mule.DefaultMuleMessage;
 import org.mule.api.MuleContext;
 import org.mule.api.MuleEvent;
@@ -17,22 +15,17 @@ import org.mule.api.MuleException;
 import org.mule.api.client.MuleClient;
 import org.mule.api.transport.OutputHandler;
 import org.mule.client.DefaultLocalMuleClient;
+import org.mule.module.http.api.client.HttpRequestOptions;
+import org.mule.module.http.api.requester.HttpStreamingType;
+import org.mule.module.http.internal.request.client.DefaultHttpRequestOptions;
 import org.mule.transport.http.HttpConnector;
 import org.mule.twitter.MuleHttpResponse;
-
-import java.io.BufferedInputStream;
-import java.io.DataOutputStream;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-
 import twitter4j.TwitterException;
-import twitter4j.internal.http.HttpClient;
-import twitter4j.internal.http.HttpClientConfiguration;
-import twitter4j.internal.http.HttpParameter;
-import twitter4j.internal.http.HttpRequest;
-import twitter4j.internal.http.HttpResponse;
-import twitter4j.internal.http.RequestMethod;
+import twitter4j.internal.http.*;
+
+import java.io.*;
+
+import static twitter4j.internal.http.RequestMethod.POST;
 
 /**
  * A version of the twitter4j client that uses Mule.
@@ -42,22 +35,22 @@ public class MuleHttpClient implements HttpClient {
     private static MuleClient client;
     private static MuleContext context;
     private final HttpClientConfiguration httpConf;
-    
-    
+
+
     public MuleHttpClient(HttpClientConfiguration conf) {
         this.httpConf = conf;
     }
-    
+
     @Override
     public HttpResponse request(final HttpRequest req) throws TwitterException {
         Object body = "";
         final boolean hasFile = HttpParameter.containsFile(req.getParameters());
         final String ctBoundary = "----Twitter4J-upload" + System.currentTimeMillis();
         final String boundary = "--" + ctBoundary;
-        
+
         if (req.getMethod().equals(RequestMethod.POST)) {
             body = new OutputHandler() {
-                
+
                 @Override
                 public void write(MuleEvent event, OutputStream os) throws IOException {
                     if (req.getMethod() == POST) {
@@ -100,7 +93,7 @@ public class MuleHttpClient implements HttpClient {
             };
         }
         DefaultMuleMessage msg = new DefaultMuleMessage(body, context);
-        
+
         if (hasFile) {
             msg.setOutboundProperty("Content-Type", "multipart/form-data; boundary=" + ctBoundary);
         } else if (req.getMethod().equals(RequestMethod.POST)) {
@@ -113,7 +106,9 @@ public class MuleHttpClient implements HttpClient {
             msg.setOutboundProperty("Authorization", authorizationHeader);
         }
         try {
-            return new MuleHttpResponse(httpConf, client.send(req.getURL(), msg));
+            HttpRequestOptions operationOptions = new DefaultHttpRequestOptions(req.getMethod().name(), true, HttpStreamingType.AUTO,
+                    null, true, true, null, new Long(httpConf.getHttpReadTimeout()));
+            return new MuleHttpResponse(httpConf, client.send(req.getURL(), msg, operationOptions));
         } catch (MuleException e) {
             throw new TwitterException(e);
         }
@@ -122,7 +117,7 @@ public class MuleHttpClient implements HttpClient {
     @Override
     public void shutdown() {
     }
-    
+
     public static void setMuleContext(MuleContext context) {
         MuleHttpClient.context = context;
         client = new DefaultLocalMuleClient(context);


### PR DESCRIPTION
1. Updated the MuleClient implementation to use 3.6 compatible libraries
2. Updated mule.version to 3.6
3. Updated the minMule version to 3.6

Note that there is still work pending on CLDCONNECT-2280. Please refer to the Jira ticket for more details.